### PR TITLE
Use scipy.spatial.ConvexHull instead of pyhull

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ CHull
 [![Build Status](https://travis-ci.org/davidavdav/CHull.jl.svg)](https://travis-ci.org/davidavdav/CHull.jl)
 
 
-A Julia wrapper around a PyCall wrapper around the qhull Convex Hull library
+A Julia wrapper around a PyCall wrapper around `scipy.spatial.ConvexHull`, which uses the qhull Convex Hull library.
 
-The qhull library for computing the convex hull of data points seems to be the standard and very widely used. 
+The qhull library for computing the convex hull of data points seems to be the standard and very widely used.
 
 This module is a quick wrapper around a Python wrapper around the library, as suggested by [Miles Lubin](https://groups.google.com/d/topic/julia-users/e9m8t5W3TVs/discussion). 
 

--- a/src/CHull.jl
+++ b/src/CHull.jl
@@ -10,19 +10,20 @@ module CHull
 export Chull, chull, display, show
 
 using PyCall
-@pyimport pyhull
-@pyimport pyhull.convex_hull as convex_hull
+@pyimport scipy.spatial as spatial
 
 type Chull{T<:Real}
-    points::Array{T}
-    vertices::Array{Int}
+    points::Array{Array{T,1},1}
+    vertices::Array{Int,1}
+    simplices::Array{Any,1}
 end
 
 function chull{T<:Real}(x::Array{T})
-    py = convex_hull.ConvexHull(x)
-    points = convert(Array,py["points"])[1]
+    py = spatial.ConvexHull(x)
+    points = convert(Array{Array{T,1},1},py["points"])
     vertices = convert(Array{Int},py["vertices"]) + 1
-    Chull(points, vertices)
+    simplices = convert(Array{Array{Int,1},1},py["simplices"]) + 1
+    Chull(points, vertices, simplices)
 end
 
 import Base.show

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,15 @@
+using Base.Test
+import CHull
+
+pts = [-1.0 0;
+       1 1;
+       3 0;
+       3 3;
+       2 2;
+       0 3;
+       -1 2]
+
+hull = CHull.chull(pts)
+@assert hull.vertices == [1, 3, 4, 6, 7]
+@assert size(hull.points) == size(pts)
+                        


### PR DESCRIPTION
After spending a significant amount of time trying to get pyhull built on my Windows machine (with no success), I discovered `scipy.spatial.ConvexHull`, which I can easily import since I have scipy already built via Anaconda. It appears to have the same functionality.

It is up to you, but doing it this way works much better for me. I also cleaned up what looked like an error or two in terms of converting the Python arrays to julia ones. I also added a very basic test. 

I will also take this opportunity to suggest that you submit this to METADATA.jl, since I think people would find it useful.