### PR TITLE
Fix simplices field type

### DIFF
--- a/src/CHull.jl
+++ b/src/CHull.jl
@@ -13,16 +13,17 @@ using PyCall
 @pyimport scipy.spatial as spatial
 
 type Chull{T<:Real}
-    points::Array{Array{T,1},1}
+    points::Array{T,2}
     vertices::Array{Int,1}
-    simplices::Array{Any,1}
+    simplices::Array{Array{Int,1},1}
 end
 
 function chull{T<:Real}(x::Array{T})
     py = spatial.ConvexHull(x)
-    points = convert(Array{Array{T,1},1},py["points"])
+    points = convert(Array{T,2},py["points"])
     vertices = convert(Array{Int},py["vertices"]) + 1
-    simplices = convert(Array{Array{Int,1},1},py["simplices"]) + 1
+    n = length(vertices)
+    simplices = convert(Array{Array{Int,1},1},py["simplices"]) + [ones(Int,2) for i = 1:n]
     Chull(points, vertices, simplices)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,4 +12,5 @@ pts = [-1.0 0;
 hull = CHull.chull(pts)
 @assert hull.vertices == [1, 3, 4, 6, 7]
 @assert size(hull.points) == size(pts)
+@assert hull.simplices == Array{Int,1}[[3,1], [4,3], [6,4], [7,1], [7,6]]
                         


### PR DESCRIPTION
This also changes `points` back to `Array{T,2}`, as it was before. Sorry about any confusion.