### PR TITLE
Plots compatability

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,0 +1,2 @@
+RecipesBase
+PyCall

--- a/src/CHull.jl
+++ b/src/CHull.jl
@@ -45,6 +45,7 @@ end
 
 using RecipesBase
 @recipe function f{T<:Chull}(val::T)
+    length(val.points[1]) && warning("Only the two first dimensions are plotted!")
     x = [x[1] for x in val.points]
     y = [x[2] for x in val.points]
     seriestype --> :shape

--- a/src/CHull.jl
+++ b/src/CHull.jl
@@ -44,12 +44,12 @@ function show(io::IO, ch::Chull)
 end
 
 using RecipesBase
-@recipe function f{T<:Chull}(::Type{T}, val::T)
+@recipe function f{T<:Chull}(val::T)
     x = [x[1] for x in val.points]
     y = [x[2] for x in val.points]
     seriestype --> :shape
     legend --> false
-    Shape(x[val.vertices], y[val.vertices])
+    x[val.vertices], y[val.vertices]
 end
 
 end

--- a/src/CHull.jl
+++ b/src/CHull.jl
@@ -1,4 +1,4 @@
-## CHull.jl 
+## CHull.jl
 ## (c) 2013 David Al van Leeuwen
 ## A Julia wrapper around a python wrapper around the qhull Convex Hull library
 
@@ -28,11 +28,11 @@ end
 
 import Base.show
 ## I don't seem to be able to print newlines in the display()
-#function display(t::TextDisplay, ch::Chull) 
+#function display(t::TextDisplay, ch::Chull)
 #    display(t, string("Convex Hull of ", size(ch.points,1), " points in ", size(ch.points,2), "dimensions"))
 #    display(t, ch.vertices)
 #    display(t, ch.points[sort(ch.vertices[:,1]),:])
-#end 
+#end
 
 ## should I use print statements in show()
 function show(io::IO, ch::Chull)
@@ -41,6 +41,15 @@ function show(io::IO, ch::Chull)
     println(io, ch.vertices)
     println(io, "Points on convex hull in original order:\n")
     println(io, ch.points[sort(ch.vertices[:,1]),:])
+end
+
+using RecipesBase
+@recipe function f{T<:Chull}(::Type{T}, val::T)
+    x = [x[1] for x in val.points]
+    y = [x[2] for x in val.points]
+    seriestype --> :shape
+    legend --> false
+    Shape(x[val.vertices], y[val.vertices])
 end
 
 end


### PR DESCRIPTION
Adds Plots.jl compatability at the cost of requiring the lightweight package RecipesBase. This allows:

```julia
using CHull, Plots
p = rand(10, 2)
ch = chull(p)
plot(ch)
```
